### PR TITLE
Autoload docker mode for Dockerfiles.

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -106,6 +106,7 @@
        '(dockerfile-font-lock-keywords nil t))
   (setq local-abbrev-table dockerfile-mode-abbrev-table))
 
+;;;###autoload
 (add-to-list 'auto-mode-alist '("Dockerfile\\'" . dockerfile-mode))
 
 (provide 'dockerfile-mode)


### PR DESCRIPTION
Adds an autoload magic comment. With this, opening a Dockerfile will enable dockerfile-mode when installed as a package.
