### PR TITLE
Correctly set require-final-newline

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -97,7 +97,7 @@
 \\{dockerfile-mode-map}
 "
   (set-syntax-table dockerfile-mode-syntax-table)
-  (set (make-local-variable 'require-final-newline) t)
+  (set (make-local-variable 'require-final-newline) mode-require-final-newline)
   (set (make-local-variable 'comment-start) "#")
   (set (make-local-variable 'comment-end) "")
   (set (make-local-variable 'comment-start-skip) "#+ *")


### PR DESCRIPTION
Emacs provides `mode-require-final-newline` to allow users to control the behaviour of modes (like `dockerfile-mode`) which are designed to control the final newline in a file. The intent is that this is set to
`t` by default - modes that wish to ensure a final newline should set `require-final-newline` to `mode-require-final-newline`, allowing users to override this behaviour. More detail can be found [here](http://www.gnu.org/software/emacs/manual/html_node/emacs/Customize-Save.html).

One specific use case where this is important is `ethan-wpace`, which implements a more sophisticated whitespace policy. Some examples of how sidestepping this convention can be a problem can be found in issues glasserc/ethan-wspace#22 and glasserc/ethan-wspace#25.