### PR TITLE
Add autoload marker for `dockerfile-build-buffer`

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -74,6 +74,7 @@
 (unless dockerfile-mode-abbrev-table
   (define-abbrev-table 'dockerfile-mode-abbrev-table ()))
 
+;;;###autoload
 (defun dockerfile-build-buffer (image-name)
   "Build an image based upon the buffer"
   (interactive


### PR DESCRIPTION
This is useful for bindings that binds to this directly.

I'm using this function in https://github.com/Silex/docker.el