### PR TITLE
dockerfile-mode.el: add LABEL to the list of known keywords

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -38,7 +38,8 @@
 (defvar dockerfile-font-lock-keywords
   `(,(cons (rx (or line-start "onbuild ")
                (group (or "from" "maintainer" "run" "cmd" "expose" "env"
-                         "add" "copy" "entrypoint" "volume" "user" "workdir" "onbuild"))
+                          "add" "copy" "entrypoint" "volume" "user" "workdir" "onbuild"
+                          "label"))
                word-boundary)
            font-lock-keyword-face)
     ,@(sh-font-lock-keywords)


### PR DESCRIPTION
LABELs are used extensively in Red Hat Dockerfiles, give them some
colors.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>