### PR TITLE
Add support for ARG command

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -37,7 +37,7 @@
 
 (defvar dockerfile-font-lock-keywords
   `(,(cons (rx (or line-start "onbuild ")
-               (group (or "from" "maintainer" "run" "cmd" "expose" "env"
+               (group (or "from" "maintainer" "run" "cmd" "expose" "env" "arg"
                           "add" "copy" "entrypoint" "volume" "user" "workdir" "onbuild"
                           "label"))
                word-boundary)


### PR DESCRIPTION
Docker 1.9 introduced the `ARG` command which can be used in combination with `docker build --build-arg`. 

See: https://github.com/docker/docker/blob/master/CHANGELOG.md#builder