### PR TITLE
Fix build failure when path of Dockerfile contains spaces.

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -90,7 +90,7 @@
   (save-buffer)
   (if (stringp image-name)
       (async-shell-command
-       (format "%s docker build -t %s -f %s %s" (if dockerfile-use-sudo "sudo" "") image-name (buffer-file-name) (file-name-directory (buffer-file-name)))
+       (format "%s docker build -t %s -f \"%s\" \"%s\"" (if dockerfile-use-sudo "sudo" "") image-name (buffer-file-name) (file-name-directory (buffer-file-name)))
        "*docker-build-output*")
     (print "docker-image-name must be a string, consider surrounding it with double quotes")))
 
@@ -104,7 +104,7 @@
   (save-buffer)
   (if (stringp image-name)
       (async-shell-command
-       (format "%s docker build --no-cache -t %s -f %s %s" (if dockerfile-use-sudo "sudo" "") image-name (buffer-file-name) (file-name-directory (buffer-file-name)))
+       (format "%s docker build --no-cache -t %s -f \"%s\" \"%s\"" (if dockerfile-use-sudo "sudo" "") image-name (buffer-file-name) (file-name-directory (buffer-file-name)))
        "*docker-build-output*")
     (print "docker-image-name must be a string, consider surrounding it with double quotes")))
 


### PR DESCRIPTION
Since the substitutions into the format call were not escaped, the shell
was interpreting paths with spaces in them as two arguments. Surrounding
said paths in spaces forces the shell to treat the literal spaces in the
path as part of the path instaead of a separator. Escaping spaces (" "
-> "\ ") would probably be a nicer solution, but the code is less
simple.