### PR TITLE
Fix inability to build images on Windows.

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -90,7 +90,7 @@
   (save-buffer)
   (if (stringp image-name)
       (async-shell-command
-       (format "%s docker build -t %s -f \"%s\" \"%s\"" (if dockerfile-use-sudo "sudo" "") image-name (buffer-file-name) (file-name-directory (buffer-file-name)))
+       (format "%sdocker build -t %s -f \"%s\" \"%s\"" (if dockerfile-use-sudo "sudo " "") image-name (buffer-file-name) (file-name-directory (buffer-file-name)))
        "*docker-build-output*")
     (print "docker-image-name must be a string, consider surrounding it with double quotes")))
 


### PR DESCRIPTION
When `dockerfile-use-sudo` was set to `nil`, the shell command for
building an image would start with a space, which had no effect on a
Linux system, but broke the ability to build on Windows. The error
message ("docker is not a docker command") seemed to indicate that a
space in front of a command causes it to double in some way, but I am
unable to duplicate a similar error in CMD, PowerShell, or Docker
Toolbox's Bash, with our without quotation marks around the command,
i.e. " docker".

Nevertheless, moving the space from the beginning of the base string to
the end of the piece inserted when `dockerfile-use-sudo` is non-`nil`
fixes the problem.

This fix does not address the problem of initializing the proper
environment variables. Emacs needs to inherit the settings suggested by
`docker-machine env` if the `docker` command is to work.