### PR TITLE
add a STOPSIGNAL Dockerfile instruction to font lock keywords

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -39,7 +39,7 @@
   `(,(cons (rx (or line-start "onbuild ")
                (group (or "from" "maintainer" "run" "cmd" "expose" "env" "arg"
                           "add" "copy" "entrypoint" "volume" "user" "workdir" "onbuild"
-                          "label"))
+                          "label" "stopsignal"))
                word-boundary)
            font-lock-keyword-face)
     ,@(sh-font-lock-keywords)


### PR DESCRIPTION
From Docker 1.9.0, added `STOPSIGNAL` Dockerfile instruction.

see: https://github.com/docker/docker/releases/tag/v1.9.0 and https://docs.docker.com/engine/reference/builder/#stopsignal 