### PR TITLE
Treat = as punctuation.

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -81,6 +81,7 @@ Each element of the list will be passed as a separate
     (modify-syntax-entry ?# "<" table)
     (modify-syntax-entry ?\n ">" table)
     (modify-syntax-entry ?' "\"" table)
+    (modify-syntax-entry ?= "." table)
     table)
   "Syntax table for `dockerfile-mode'.")
 


### PR DESCRIPTION
Previously, = was treated as a symbol character. This prevented things
like highlight-symbol-mode and isearch-forward-symbol being able to
find variables defined with `ENV FOO=1`.