### PR TITLE
Recognize Dockerfile files with extension

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -169,7 +169,7 @@ If prefix arg NO-CACHE is set, don't cache the image."
   (setq local-abbrev-table dockerfile-mode-abbrev-table))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("Dockerfile\\'" . dockerfile-mode))
+(add-to-list 'auto-mode-alist '("Dockerfile\\(?:\\..*\\)?\\'" . dockerfile-mode))
 
 (provide 'dockerfile-mode)
 


### PR DESCRIPTION
Make filenames like `Dockerfile.example` or `Dockerfile.build` also 
open with `dockerfile-mode` automatically.