### PR TITLE
README.md addition for safe-local-variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,8 @@ at the top of your Dockerfile.
 ```
 
 If you don't, you'll be prompted for an image name each time you build.
+You may want to add the following to your emacs config:
+
+``` emacs-lisp
+(put 'dockerfile-image-name 'safe-local-variable #'stringp)
+```


### PR DESCRIPTION
This tells emacs that setting the local variable `dockerfile-image-name` to any string is safe, and it need not confirm with you. Cribbed from [stack overflow](https://stackoverflow.com/a/19813210).