### PR TITLE
Add imenu support

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -63,6 +63,9 @@ Each element of the list will be passed as a separate
   '((t (:inherit (font-lock-constant-face bold))))
   "Face to highlight the base image alias inf FROM ... AS <alias> construct.")
 
+(defconst dockerfile--from-regex
+  (rx "from " (group (+? nonl)) (or " " eol) (? "as " (group (1+ nonl)))))
+
 (defvar dockerfile-font-lock-keywords
   `(,(cons (rx (or line-start "onbuild ")
                (group (or "from" "maintainer" "run" "cmd" "expose" "env" "arg"
@@ -70,7 +73,7 @@ Each element of the list will be passed as a separate
                           "label" "stopsignal" "shell" "healthcheck"))
                word-boundary)
            font-lock-keyword-face)
-    (,(rx "FROM " (group (+? nonl)) (or " " eol) (? "as " (group (1+ nonl))))
+    (,dockerfile--from-regex
      (1 'dockerfile-image-name)
      (2 'dockerfile-image-alias nil t))
     ,@(sh-font-lock-keywords)
@@ -164,12 +167,28 @@ If prefix arg NO-CACHE is set, don't cache the image."
   (interactive (list (dockerfile-read-image-name)))
   (dockerfile-build-buffer image-name t))
 
+(defun dockerfile--imenu-function ()
+  "Find the previous headline from point.
+
+Search for a FROM instruction.  If an alias is used this is
+returned, otherwise the base image name is used."
+  (when (re-search-backward dockerfile--from-regex nil t)
+    (let ((data (match-data)))
+      (when (match-string 2)
+        ;; we drop the first match group because
+        ;; imenu-generic-expression can only use one offset, so we
+        ;; normalize to `1'.
+        (set-match-data (list (nth 0 data) (nth 1 data) (nth 4 data) (nth 5 data))))
+      t)))
+
 ;;;###autoload
 (define-derived-mode dockerfile-mode prog-mode "Dockerfile"
   "A major mode to edit Dockerfiles.
 \\{dockerfile-mode-map}
 "
   (set-syntax-table dockerfile-mode-syntax-table)
+  (set (make-local-variable 'imenu-generic-expression)
+       `(("Stage" dockerfile--imenu-function 1)))
   (set (make-local-variable 'require-final-newline) mode-require-final-newline)
   (set (make-local-variable 'comment-start) "#")
   (set (make-local-variable 'comment-end) "")


### PR DESCRIPTION
The build stages can now be accessed with `imenu`.