### PR TITLE
Fix remote build when editing Dockerfile through tramp.

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -135,13 +135,20 @@ indented by one `tab-width'."
   (mapconcat (lambda (arg) (concat "--build-arg " (shell-quote-argument arg)))
              dockerfile-build-args " "))
 
+(defun dockerfile-untrampify (file)
+  "Remove tramp syntax if present to be consumed on remote systems"
+  (if (tramp-tramp-file-p file)
+      (tramp-file-name-localname (tramp-dissect-file-name file))
+    file))
+
 (defun dockerfile-standard-filename (file)
   "Convert the FILE name to OS standard.
 If in Cygwin environment, uses Cygwin specific function to convert the
 file name.  Otherwise, uses Emacs' standard conversion function."
-  (if (fboundp 'cygwin-convert-file-name-to-windows)
-      (s-replace "\\" "\\\\" (cygwin-convert-file-name-to-windows file))
-    (convert-standard-filename file)))
+  (let ((local-file (dockerfile-untrampify file)))
+    (if (fboundp 'cygwin-convert-file-name-to-windows)
+        (s-replace "\\" "\\\\" (cygwin-convert-file-name-to-windows local-file))
+      (convert-standard-filename local-file))))
 
 (defvar dockerfile-image-name nil
   "Name of the dockerfile currently being used.

--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -135,17 +135,11 @@ indented by one `tab-width'."
   (mapconcat (lambda (arg) (concat "--build-arg " (shell-quote-argument arg)))
              dockerfile-build-args " "))
 
-(defun dockerfile-untrampify (file)
-  "Remove tramp syntax if present to be consumed on remote systems"
-  (if (tramp-tramp-file-p file)
-      (tramp-file-name-localname (tramp-dissect-file-name file))
-    file))
-
 (defun dockerfile-standard-filename (file)
   "Convert the FILE name to OS standard.
 If in Cygwin environment, uses Cygwin specific function to convert the
 file name.  Otherwise, uses Emacs' standard conversion function."
-  (let ((local-file (dockerfile-untrampify file)))
+  (let ((local-file (file-local-name file)))
     (if (fboundp 'cygwin-convert-file-name-to-windows)
         (s-replace "\\" "\\\\" (cygwin-convert-file-name-to-windows local-file))
       (convert-standard-filename local-file))))


### PR DESCRIPTION
When editing a Dockerfile on a remote host through tramp, (buffer-file-name) will be a tramp location (i.e. "/ssh:hostname:dir/to/Dockerfile"), which docker does not understand. This change extracts the local path component on the remote host to allow docker to find the file.