### PR TITLE
Make it possible to use a differnt binary than in the path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,8 @@ You may want to add the following to your emacs config:
 ``` emacs-lisp
 (put 'dockerfile-image-name 'safe-local-variable #'stringp)
 ```
+
+You can change the binary to use with
+```emacs-lisp
+(setq dockerfile-mode-command "docker")
+```

--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -42,6 +42,11 @@
   :type 'hook
   :group 'dockerfile)
 
+(defcustom dockerfile-mode-command "docker"
+  "Which binary to use to build images"
+  :group 'dockerfile
+  :type 'string)
+
 (defcustom dockerfile-use-sudo nil
   "Runs docker builder command with sudo."
   :type 'boolean
@@ -165,8 +170,9 @@ If prefix arg NO-CACHE is set, don't cache the image."
   (if (stringp image-name)
       (compilation-start
        (format
-        "%sdocker build %s -t %s %s -f %s %s"
+        "%s%s build %s -t %s %s -f %s %s"
         (if dockerfile-use-sudo "sudo " "")
+	dockerfile-mode-command
         (if no-cache "--no-cache" "")
         (shell-quote-argument image-name)
         (dockerfile-build-arg-string)


### PR DESCRIPTION
Make it possible to use a different binary than the docker command in the PATH. With this it is also possible to use podman instead of docker. 