### PR TITLE
added: dockerfile-indent-offset closed #16

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -60,7 +60,7 @@ Each element of the list will be passed as a separate
   :type '(repeat string)
   :group 'dockerfile)
 
-(defcustom dockerfile-indent-offset (and standard-indent 2)
+(defcustom dockerfile-indent-offset (or standard-indent 2)
   "Dockerfile number of columns for margin-changing functions to indent."
   :type 'integer
   :safe #'integerp

--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -60,6 +60,12 @@ Each element of the list will be passed as a separate
   :type '(repeat string)
   :group 'dockerfile)
 
+(defcustom dockerfile-indent-offset (and standard-indent 2)
+  "Dockerfile number of columns for margin-changing functions to indent."
+  :type 'integer
+  :safe #'integerp
+  :group 'dockerfile)
+
 (defface dockerfile-image-name
   '((t (:inherit (font-lock-type-face bold))))
   "Face to highlight the base image name after FROM instruction.")
@@ -123,7 +129,7 @@ Each element of the list will be passed as a separate
   "Indent lines in a Dockerfile.
 
 Lines beginning with a keyword are ignored, and any others are
-indented by one `tab-width'."
+indented by one `dockerfile-indent-offset'."
   (unless (member (get-text-property (point-at-bol) 'face)
                   '(font-lock-comment-delimiter-face font-lock-keyword-face))
     (save-excursion
@@ -132,7 +138,7 @@ indented by one `tab-width'."
       (unless (equal (point) (point-at-eol)) ; Ignore empty lines.
         ;; Delete existing whitespace.
         (delete-char (- (point-at-bol) (point)))
-        (indent-to tab-width)))))
+        (indent-to dockerfile-indent-offset)))))
 
 (defun dockerfile-build-arg-string ()
   "Create a --build-arg string for each element in `dockerfile-build-args'."


### PR DESCRIPTION
`tab-width` is not the size of an indentation step.

> NOTE: This controls the display width of a TAB character, and not the size of an indentation step.
>
> see `describe-variable` `tab-width`

So, I add dockerfile-indent-offset and respect `standard-indent`.