### PR TITLE
FIX: make emacs lisp variable name consistent in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you don't, you'll be prompted for an image name each time you build.
 You may want to add the following to your emacs config:
 
 ``` emacs-lisp
-(put 'dockerfile-image-name 'safe-local-variable #'stringp)
+(put 'docker-image-name 'safe-local-variable #'stringp)
 ```
 
 You can change the binary to use with


### PR DESCRIPTION
Minor change... the README.md had an inconsistent variable name. I spent ~10 minutes googling and trying to figure out why `(put 'dockerfile-image-name 'safe-local-variable #'stringp)` wasn't working until realizing the variable name was not consistent with the example image name tag above. Maybe this PR will save someone else that time. 😃 