### PR TITLE
fix define-obsolete-function-alias error in Emacs28

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -154,7 +154,7 @@ file name.  Otherwise, uses Emacs' standard conversion function."
 (defvar dockerfile-image-name nil
   "Name of the dockerfile currently being used.
 This can be set in file or directory-local variables.")
-(define-obsolete-variable-alias 'docker-image-name 'dockerfile-image-name)
+(define-obsolete-variable-alias 'docker-image-name 'dockerfile-image-name "2017-10-22")
 
 (defvar dockerfile-image-name-history nil
   "History of image names read by `dockerfile-read-image-name'.")


### PR DESCRIPTION
According to HEAD NEWS, 'The 'when' argument of `make-obsolete` and related functions is mandatory'.