### PR TITLE
fix: false positives caused by auto-mode-alist pattern

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -241,7 +241,10 @@ returned, otherwise the base image name is used."
   (set (make-local-variable 'indent-line-function) #'dockerfile-indent-line-function))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("Dockerfile\\(?:\\..*\\)?\\'" . dockerfile-mode))
+(add-to-list 'auto-mode-alist '("/Dockerfile\\(?:\\..*\\)?\\'" . dockerfile-mode))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.dockerfile\\'" . dockerfile-mode))
 
 (provide 'dockerfile-mode)
 


### PR DESCRIPTION
The old pattern would match the following filenames:

- `*Dockerfile`
- `*Dockerfile.*`

This is because the pattern does not start with a slash indicating the beginning
of the basename. Personally this led to a few false positives, like for example
`siren-dockerfile.el` that sets up and configures dockerfile-mode in my Emacs
configuration.

This change restricts the patterns to:

- `Dockerfile`
- `Dockerfile.*`
- `*.dockerfile`

I believe this is still wide enough to capture all common naming conventions for
Dockerfiles.