### PR TITLE
Remove unnecessary declaration of dockerfile-mode-hook

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -36,11 +36,6 @@
   :prefix "dockerfile-"
   :group 'languages)
 
-(defcustom dockerfile-mode-hook nil
-  "*Hook called by `dockerfile-mode'."
-  :type 'hook
-  :group 'dockerfile)
-
 (defcustom dockerfile-mode-command "docker"
   "Which binary to use to build images."
   :group 'dockerfile


### PR DESCRIPTION
The invocation of define-derived-mode defines the hook.