### PR TITLE
Add --pull and --force-rm switches toggling defcustoms.

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -49,6 +49,16 @@
   :type 'boolean
   :group 'dockerfile)
 
+(defcustom dockerfile-build-force-rm nil
+  "Runs docker builder command with --force-rm switch."
+  :type 'boolean
+  :group 'dockerfile)
+
+(defcustom dockerfile-build-pull nil
+  "Runs docker builder command with --pull switch."
+  :type 'boolean
+  :group 'dockerfile)
+
 (defcustom dockerfile-build-args nil
   "List of --build-arg to pass to docker build.
 
@@ -195,11 +205,13 @@ The build string will be of the format:
   (save-buffer)
     (compilation-start
         (format
-            "%s%s%s build %s %s %s -f %s %s"
+            "%s%s%s build %s %s %s %s %s -f %s %s"
             (if dockerfile-use-buildkit "DOCKER_BUILDKIT=1 " "")
             (if dockerfile-use-sudo "sudo " "")
             dockerfile-mode-command
             (if no-cache "--no-cache" "")
+            (if dockerfile-build-force-rm "--force-rm " "")
+            (if dockerfile-build-pull "--pull " "")
             (dockerfile-tag-string image-name)
             (dockerfile-build-arg-string)
             (shell-quote-argument (dockerfile-standard-filename


### PR DESCRIPTION
`docker build` supports two handy switches:
- `--force-rm` to remove build containers on build error.
- `--pull` to force checking of base image and pulling it if more recent.

Two new `defcustoms` have been defined, respectively:
- `dockerfile-build-force-rm`
- `dockerfile-build-pull`

Both default to `nil` to keep current behavior.