### PR TITLE
Remove unnecessary configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ A Dockerfile mode for emacs
 ``` emacs-lisp
 (add-to-list 'load-path "/your/path/to/dockerfile-mode/")
 (require 'dockerfile-mode)
-(add-to-list 'auto-mode-alist '("Dockerfile\\'" . dockerfile-mode))
 ```
 
 Adds syntax highlighting as well as the ability to build the image


### PR DESCRIPTION
That line is no longer necessary because `auto-mode-alist` is set by below part.

https://github.com/spotify/dockerfile-mode/blob/11c43de04b128b7638cd98a1e80be2b661c18fbb/dockerfile-mode.el#L264-L269