### PR TITLE
Recognize Containerfile

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -268,8 +268,11 @@ returned, otherwise the base image name is used."
   (set (make-local-variable 'indent-line-function) #'dockerfile-indent-line-function))
 
 ;;;###autoload
-(add-to-list 'auto-mode-alist '("/Dockerfile\\(?:\\.[^/\\]*\\)?\\'" .
-                                dockerfile-mode))
+(add-to-list 'auto-mode-alist
+             (cons (concat "[/\\]"
+                           "\\(?:Containerfile\\|Dockerfile\\)"
+                           "\\(?:\\.[^/\\]*\\)?\\'")
+                   'dockerfile-mode))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.dockerfile\\'" . dockerfile-mode))


### PR DESCRIPTION
"Containerfile" is a renaming of "Dockerfile" used by Buildah, Podman,
etc. The same syntax is used.

https://www.mankier.com/5/Containerfile