### PR TITLE
Remove obsolete function calls

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -156,7 +156,7 @@ Lines beginning with a keyword are ignored, and any others are
 indented by one `dockerfile-indent-offset'. Functionality toggled
 by `dockerfile-enable-auto-indent'."
   (when dockerfile-enable-auto-indent
-    (unless (member (get-text-property (point-at-bol) 'face)
+    (unless (member (get-text-property (line-beginning-position) 'face)
              '(font-lock-comment-delimiter-face font-lock-keyword-face))
      (save-excursion
        (beginning-of-line)


### PR DESCRIPTION
In Emacs 29.1 the `point-at-bol` and `point-at-eol` functions are obsolete. This removes the following warnings when compiling the file:

    In dockerfile-indent-line-function:
    dockerfile-mode.el:159:41: Warning: ‘point-at-bol’ is an obsolete function (as
        of 29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
    dockerfile-mode.el:163:37: Warning: ‘point-at-eol’ is an obsolete function (as
        of 29.1); use ‘line-end-position’ or ‘pos-eol’ instead.
    dockerfile-mode.el:164:32: Warning: ‘point-at-eol’ is an obsolete function (as
        of 29.1); use ‘line-end-position’ or ‘pos-eol’ instead.
    dockerfile-mode.el:166:27: Warning: ‘point-at-bol’ is an obsolete function (as
        of 29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.

It is safe to use these new functions as they were introduced as of Emacs 20.