### PR TITLE
Do not modify indentation if there's nothing to modify

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -160,8 +160,7 @@ by `dockerfile-enable-auto-indent'."
              '(font-lock-comment-delimiter-face font-lock-keyword-face))
      (save-excursion
        (beginning-of-line)
-       (skip-chars-forward "[ \t]" (point-at-eol))
-       (unless (equal (point) (point-at-eol)) ; Ignore empty lines.
+       (unless (looking-at-p "\\s-*$") ; Ignore empty lines.
          (indent-line-to dockerfile-indent-offset))))))
 
 (defun dockerfile-build-arg-string ()

--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -162,9 +162,7 @@ by `dockerfile-enable-auto-indent'."
        (beginning-of-line)
        (skip-chars-forward "[ \t]" (point-at-eol))
        (unless (equal (point) (point-at-eol)) ; Ignore empty lines.
-         ;; Delete existing whitespace.
-         (delete-char (- (point-at-bol) (point)))
-         (indent-to dockerfile-indent-offset))))))
+         (indent-line-to dockerfile-indent-offset))))))
 
 (defun dockerfile-build-arg-string ()
   "Create a --build-arg string for each element in `dockerfile-build-args'."


### PR DESCRIPTION
The older code has been always deleting the whitespace, even if indentation is already as expected. Fix that by replacing `indent-to` with `indent-line-to` which avoids modifying the line if there's nothing to modify.

As a bonus, this simplifies the code.