### PR TITLE
Add s to Package-Requires list

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -1,7 +1,7 @@
 ;;; dockerfile-mode.el --- Major mode for editing Docker's Dockerfiles -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2013 Spotify AB
-;; Package-Requires: ((emacs "24"))
+;; Package-Requires: ((emacs "24") (s "1.2.0"))
 ;; Homepage: https://github.com/spotify/dockerfile-mode
 ;; URL: https://github.com/spotify/dockerfile-mode
 ;; Version: 1.7


### PR DESCRIPTION
After afcd418, dockerfile-mode fails to load with:

```
File mode specification error: (file-missing Cannot open load file No such file or directory s)
```

This is because dockerfile-mode depends now on the function
`s-replace`, which is provided by the `s` package. This commit adds
`s` to the list of dependencies of dockerfile-mode.

Fixes #83.