### PR TITLE
Make sure to quote font-lock-keyword-face

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -118,7 +118,7 @@ It is supported from docker 18.09"
                           "add" "copy" "entrypoint" "volume" "user" "workdir" "onbuild"
                           "label" "stopsignal" "shell" "healthcheck"))
                word-boundary)
-           font-lock-keyword-face)
+           'font-lock-keyword-face)
     (,dockerfile--from-regex
      (1 'dockerfile-image-name)
      (2 'dockerfile-image-alias nil t))


### PR DESCRIPTION
Fixes a warning:

      dockerfile-mode.el:121:12: Warning: ‘font-lock-keyword-face’ is an obsolete variable (as of 31.1); use the quoted symbol instead: 'font-lock-keyword-face