### PR TITLE
Fix missing "Build" menu item and stabilize menu order

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -137,10 +137,10 @@ It is supported from docker 18.09"
     (define-key menu-map [dfc]
       '(menu-item "Comment Region" comment-region
                   :help "Comment Region"))
-    (define-key menu-map [dfb]
+    (define-key-after menu-map [dfb]
       '(menu-item "Build" dockerfile-build-buffer
                   :help "Send the Dockerfile to docker build"))
-    (define-key menu-map [dfbnc]
+    (define-key-after menu-map [dfbnc]
       '(menu-item "Build without cache" dockerfile-build-no-cache-buffer
                   :help "Send the Dockerfile to docker build without cache"))
     map))

--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -140,7 +140,7 @@ It is supported from docker 18.09"
     (define-key menu-map [dfb]
       '(menu-item "Build" dockerfile-build-buffer
                   :help "Send the Dockerfile to docker build"))
-    (define-key menu-map [dfb]
+    (define-key menu-map [dfbnc]
       '(menu-item "Build without cache" dockerfile-build-no-cache-buffer
                   :help "Send the Dockerfile to docker build without cache"))
     map))


### PR DESCRIPTION
## Problem

- The Dockerfile menu bound both "Build" and "Build without cache" to `[dfb]`, so "Build" was overwritten and not shown.
- Menu item order depended on keymap insertion behavior.

## Change

* Assign a unique key to "Build without cache."
* Use `define-key-after` to enforce a deterministic menu order.
