### PR TITLE
Support `FROM --platform=...` in FROM parsing

### DIFF
--- a/dockerfile-mode.el
+++ b/dockerfile-mode.el
@@ -110,7 +110,14 @@ It is supported from docker 18.09"
   "Face to highlight the base image alias inf FROM ... AS <alias> construct.")
 
 (defconst dockerfile--from-regex
-  (rx "from " (group (+? nonl)) (or (1+ " ") eol) (? "as " (group (1+ nonl)))))
+  (rx line-start (* blank) "from" (+ blank)
+      (? "--platform=" (+ (not (any blank "\n"))) (+ blank))
+      (group (+ (not (any blank "\n"))))
+      (* blank)
+      (? "as" (+ blank) (group (+ (not (any blank "\n")))))
+      (* blank)
+      (? "#" (* nonl))
+      line-end))
 
 (defvar dockerfile-font-lock-keywords
   `(,(cons (rx (or line-start "onbuild ")


### PR DESCRIPTION
## Problem

For `FROM` lines that include `--platform=...` (e.g. `FROM --platform=linux/amd64 ubuntu:24.04 AS base`), the current `dockerfile--from-regex` can capture the `--platform=...` token as the image name, which breaks font-lock highlighting and imenu stage detection.

<img width="692" height="652" alt="Before: --platform token is highlighted as the image name in FROM --platform=..." src="https://github.com/user-attachments/assets/5723486a-0754-4206-a6b7-0978214e8f65" />

## Change

Update `dockerfile--from-regex` to optionally consume `--platform=<token>` immediately after `FROM`, then capture:

* group 1: the image name (e.g. `ubuntu:24.04`)
* group 2: the optional alias after `AS` (e.g. `base`)

Capture group numbering is preserved so existing font-lock / imenu consumers keep working.

<img width="692" height="652" alt="After: image name and AS alias are highlighted correctly in FROM --platform=..." src="https://github.com/user-attachments/assets/5765b8be-7873-4186-93a8-5821183da834" />
